### PR TITLE
feat(network): add external envoy gateway

### DIFF
--- a/kubernetes/apps/default/charali/helmrelease.yaml
+++ b/kubernetes/apps/default/charali/helmrelease.yaml
@@ -45,6 +45,8 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+          - name: envoy-external
+            namespace: network
         rules:
           - matches:
               - path:

--- a/kubernetes/apps/default/fresh-rss/helmrelease.yaml
+++ b/kubernetes/apps/default/fresh-rss/helmrelease.yaml
@@ -76,6 +76,8 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+          - name: envoy-external
+            namespace: network
         rules:
           - matches:
               - path:

--- a/kubernetes/apps/default/investment/helmrelease.yaml
+++ b/kubernetes/apps/default/investment/helmrelease.yaml
@@ -43,6 +43,8 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+          - name: envoy-external
+            namespace: network
         rules:
           - matches:
               - path:

--- a/kubernetes/apps/default/lubelogger/helmrelease.yaml
+++ b/kubernetes/apps/default/lubelogger/helmrelease.yaml
@@ -83,6 +83,8 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+          - name: envoy-external
+            namespace: network
         rules:
           - matches:
               - path:

--- a/kubernetes/apps/default/nepse/helmrelease.yaml
+++ b/kubernetes/apps/default/nepse/helmrelease.yaml
@@ -61,6 +61,8 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+          - name: envoy-external
+            namespace: network
         rules:
           - matches:
               - path:

--- a/kubernetes/apps/default/radicale/helmrelease.yaml
+++ b/kubernetes/apps/default/radicale/helmrelease.yaml
@@ -81,6 +81,8 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+          - name: envoy-external
+            namespace: network
         rules:
           - matches:
               - path:

--- a/kubernetes/apps/default/silverbullet/helmrelease.yaml
+++ b/kubernetes/apps/default/silverbullet/helmrelease.yaml
@@ -63,6 +63,8 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+          - name: envoy-external
+            namespace: network
         rules:
           - matches:
               - path:

--- a/kubernetes/apps/media/jellyfin/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/helmrelease.yaml
@@ -118,6 +118,8 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+          - name: envoy-external
+            namespace: network
         rules:
           - matches:
               - path:

--- a/kubernetes/apps/media/jellyseerr/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyseerr/helmrelease.yaml
@@ -61,6 +61,8 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+          - name: envoy-external
+            namespace: network
         rules:
           - matches:
               - path:

--- a/kubernetes/apps/music/navidrome/helmrelease.yaml
+++ b/kubernetes/apps/music/navidrome/helmrelease.yaml
@@ -98,6 +98,8 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+          - name: envoy-external
+            namespace: network
         rules:
           - matches:
               - path:

--- a/kubernetes/apps/network/cloudflared/configs/config.yaml
+++ b/kubernetes/apps/network/cloudflared/configs/config.yaml
@@ -7,67 +7,67 @@ originRequest:
 ingress:
   # Root homelab domain
   - hostname: ${HOMELAB_DOMAIN}
-    service: http://envoy-internal.network.svc.cluster.local
+    service: http://envoy-external.network.svc.cluster.local
     originRequest:
       httpHostHeader: ${HOMELAB_DOMAIN}
 
   # NEPSE
   - hostname: nepse.${HOMELAB_DOMAIN}
-    service: http://envoy-internal.network.svc.cluster.local
+    service: http://envoy-external.network.svc.cluster.local
     originRequest:
       httpHostHeader: nepse.${HOMELAB_DOMAIN}
 
   # Investment
   - hostname: investment.${HOMELAB_DOMAIN}
-    service: http://envoy-internal.network.svc.cluster.local
+    service: http://envoy-external.network.svc.cluster.local
     originRequest:
       httpHostHeader: investment.${HOMELAB_DOMAIN}
 
   # Jellyfin (movies)
   - hostname: movies.${HOMELAB_DOMAIN}
-    service: http://envoy-internal.network.svc.cluster.local
+    service: http://envoy-external.network.svc.cluster.local
     originRequest:
       httpHostHeader: jellyfin.${HOMELAB_DOMAIN}
 
   # Jellyseerr (movie requests)
   - hostname: movie-request.${HOMELAB_DOMAIN}
-    service: http://envoy-internal.network.svc.cluster.local
+    service: http://envoy-external.network.svc.cluster.local
     originRequest:
       httpHostHeader: jellyseerr.${HOMELAB_DOMAIN}
 
   # SilverBullet (notes)
   - hostname: notes.${HOMELAB_DOMAIN}
-    service: http://envoy-internal.network.svc.cluster.local
+    service: http://envoy-external.network.svc.cluster.local
     originRequest:
       httpHostHeader: notes.${HOMELAB_DOMAIN}
 
   # Radicale (calendar/contacts)
   - hostname: radicale.${HOMELAB_DOMAIN}
-    service: http://envoy-internal.network.svc.cluster.local
+    service: http://envoy-external.network.svc.cluster.local
     originRequest:
       httpHostHeader: radicale.${HOMELAB_DOMAIN}
 
   # FreshRSS (rss)
   - hostname: rss.${HOMELAB_DOMAIN}
-    service: http://envoy-internal.network.svc.cluster.local
+    service: http://envoy-external.network.svc.cluster.local
     originRequest:
       httpHostHeader: rss.${HOMELAB_DOMAIN}
 
   # Vehicle tracker
   - hostname: vehicle.${HOMELAB_DOMAIN}
-    service: http://envoy-internal.network.svc.cluster.local
+    service: http://envoy-external.network.svc.cluster.local
     originRequest:
       httpHostHeader: vehicle.${HOMELAB_DOMAIN}
 
   # Movary (on public domain)
   # - hostname: movies.${PUBLIC_DOMAIN}
-  #   service: http://envoy-internal.network.svc.cluster.local
+  #   service: http://envoy-external.network.svc.cluster.local
   #   originRequest:
   #     httpHostHeader: movary.${HOMELAB_DOMAIN}
 
   # Navidrome (on public domain)
   - hostname: music.${PUBLIC_DOMAIN}
-    service: http://envoy-internal.network.svc.cluster.local
+    service: http://envoy-external.network.svc.cluster.local
     originRequest:
       httpHostHeader: navidrome.${HOMELAB_DOMAIN}
 

--- a/kubernetes/apps/network/envoy-gateway/gateway/gateway.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gateway/gateway.yaml
@@ -24,3 +24,17 @@ spec:
             name: homelab-root-tls-cert
           - kind: Secret
             name: homelab-wildcard-tls-cert
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: envoy-external
+spec:
+  gatewayClassName: envoy
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All


### PR DESCRIPTION
Add a dedicated envoy-external Gateway for Cloudflare Tunnel traffic and point cloudflared at it instead of the internal gateway.

Only routes for apps currently exposed through Cloudflare attach to envoy-external, keeping internal-only routes isolated on envoy-internal.

The external gateway accepts HTTP from cloudflared because public TLS terminates at Cloudflare before tunnel traffic reaches the cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated routing configurations to enable external gateway access for multiple services.
  * Added new external gateway configuration for enhanced routing capabilities.
  * Updated tunnel ingress routing to direct traffic through external endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adityathebe/homelab/pull/934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->