### PR TITLE
feat(envoy-gateway): add external client IP logging

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/gateway/client-traffic-policy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gateway/client-traffic-policy.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: envoy-external-client-ip
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: envoy-external
+  clientIPDetection:
+    xForwardedFor:
+      numTrustedHops: 1

--- a/kubernetes/apps/network/envoy-gateway/gateway/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gateway/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./certs.yaml
+  - ./client-traffic-policy.yaml
   - ./gateway.yaml

--- a/kubernetes/apps/network/envoy-gateway/gatewayclass/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gatewayclass/envoy.yaml
@@ -24,6 +24,40 @@ spec:
   shutdown:
     drainTimeout: 180s
   telemetry:
+    accessLog:
+      settings:
+        - sinks:
+            - type: File
+              file:
+                path: /dev/stdout
+          format:
+            type: JSON
+            json:
+              client_ip: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
+              start_time: "%START_TIME%"
+              method: "%REQ(:METHOD)%"
+              x-envoy-origin-path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+              protocol: "%PROTOCOL%"
+              response_code: "%RESPONSE_CODE%"
+              response_flags: "%RESPONSE_FLAGS%"
+              response_code_details: "%RESPONSE_CODE_DETAILS%"
+              connection_termination_details: "%CONNECTION_TERMINATION_DETAILS%"
+              upstream_transport_failure_reason: "%UPSTREAM_TRANSPORT_FAILURE_REASON%"
+              bytes_received: "%BYTES_RECEIVED%"
+              bytes_sent: "%BYTES_SENT%"
+              duration: "%DURATION%"
+              x-envoy-upstream-service-time: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"
+              x-forwarded-for: "%REQ(X-FORWARDED-FOR)%"
+              user-agent: "%REQ(USER-AGENT)%"
+              x-request-id: "%REQ(X-REQUEST-ID)%"
+              ":authority": "%REQ(:AUTHORITY)%"
+              upstream_host: "%UPSTREAM_HOST%"
+              upstream_cluster: "%UPSTREAM_CLUSTER%"
+              upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+              downstream_local_address: "%DOWNSTREAM_LOCAL_ADDRESS%"
+              downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
+              requested_server_name: "%REQUESTED_SERVER_NAME%"
+              route_name: "%ROUTE_NAME%"
     metrics:
       prometheus: {}
 ---


### PR DESCRIPTION
Envoy external access logs currently expose the full `x-forwarded-for` chain, including the internal cloudflared pod IP.

Configure `envoy-external` to derive the client address from XFF with one trusted hop, then add a `client_ip` JSON log field for cleaner Loki/Grafana queries.

This keeps the existing log fields intact while making external client IPs directly queryable.