### PR TITLE
feat: add Envoy Gateway Grafana dashboard

### DIFF
--- a/kubernetes/apps/monitoring/grafana/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/helmrelease.yaml
@@ -94,6 +94,11 @@ spec:
           gnetId: 20417
           revision: 4
           datasource: Prometheus
+        envoy-gateway-overview:
+          # renovate: depName="Envoy Gateway / Overview"
+          gnetId: 24460
+          revision: 1
+          datasource: Prometheus
         speedtest-exporter:
           url: https://raw.githubusercontent.com/adityathebe/speedtest-exporter/refs/heads/main/monitoring/grafana_dashboard.json
           datasource: Prometheus


### PR DESCRIPTION
Adds the Envoy Gateway / Overview Grafana dashboard to the monitoring stack.

This provisions the upstream Grafana dashboard for Envoy Gateway metrics using the existing Prometheus datasource, making gateway health and XDS activity visible in Grafana.