### PR TITLE
feat(envoy-gateway): add controller metrics monitoring

### DIFF
--- a/kubernetes/apps/monitoring/grafana/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/helmrelease.yaml
@@ -99,6 +99,11 @@ spec:
           gnetId: 24460
           revision: 1
           datasource: Prometheus
+        envoy-overview:
+          # renovate: depName="Envoy / Overview"
+          gnetId: 24459
+          revision: 1
+          datasource: Prometheus
         speedtest-exporter:
           url: https://raw.githubusercontent.com/adityathebe/speedtest-exporter/refs/heads/main/monitoring/grafana_dashboard.json
           datasource: Prometheus

--- a/kubernetes/apps/network/envoy-gateway/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/network/envoy-gateway/servicemonitor.yaml
+++ b/kubernetes/apps/network/envoy-gateway/servicemonitor.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: envoy-gateway
+spec:
+  namespaceSelector:
+    matchNames:
+      - network
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: envoy-gateway
+      app.kubernetes.io/name: gateway-helm
+      control-plane: envoy-gateway
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 1m
+      scrapeTimeout: 10s


### PR DESCRIPTION
Adds a ServiceMonitor for the Envoy Gateway controller metrics service so the gateway overview dashboard has control-plane data.

Also adds the Envoy proxy overview Grafana dashboard for data-plane metrics collected from the existing Envoy PodMonitor.