### PR TITLE
chore: require non-root HelmRelease pods

### DIFF
--- a/kubernetes/apps/dbms/cloudnative-pg/helmrelease.yaml
+++ b/kubernetes/apps/dbms/cloudnative-pg/helmrelease.yaml
@@ -26,6 +26,8 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    podSecurityContext:
+      runAsNonRoot: true
     crds:
       create: true
     resources:

--- a/kubernetes/apps/default/actualbudget/helmrelease.yaml
+++ b/kubernetes/apps/default/actualbudget/helmrelease.yaml
@@ -23,6 +23,9 @@ spec:
     remediation:
       retries: 5
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       actualbudget:
         annotations:

--- a/kubernetes/apps/default/charali/helmrelease.yaml
+++ b/kubernetes/apps/default/charali/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         containers:

--- a/kubernetes/apps/default/echo-server/helmrelease.yaml
+++ b/kubernetes/apps/default/echo-server/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         annotations:

--- a/kubernetes/apps/default/fresh-rss/helmrelease.yaml
+++ b/kubernetes/apps/default/fresh-rss/helmrelease.yaml
@@ -29,6 +29,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       freshrss:
         annotations:

--- a/kubernetes/apps/default/gickup/helmrelease.yaml
+++ b/kubernetes/apps/default/gickup/helmrelease.yaml
@@ -26,6 +26,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         type: cronjob

--- a/kubernetes/apps/default/homepage/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/helmrelease.yaml
@@ -23,6 +23,9 @@ spec:
     remediation:
       retries: 5
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       homepage:
         serviceAccount:

--- a/kubernetes/apps/default/investment/helmrelease.yaml
+++ b/kubernetes/apps/default/investment/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         strategy: Recreate

--- a/kubernetes/apps/default/ittools/helmrelease.yaml
+++ b/kubernetes/apps/default/ittools/helmrelease.yaml
@@ -23,6 +23,9 @@ spec:
     remediation:
       retries: 5
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         containers:

--- a/kubernetes/apps/default/lubelogger/helmrelease.yaml
+++ b/kubernetes/apps/default/lubelogger/helmrelease.yaml
@@ -24,6 +24,9 @@ spec:
       strategy: rollback
       retries: 3
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       lubelogger:
         labels:

--- a/kubernetes/apps/default/nepse/helmrelease.yaml
+++ b/kubernetes/apps/default/nepse/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         strategy: Recreate

--- a/kubernetes/apps/default/paperless/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
         namespace: flux-system
       interval: 15m
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       paperless:
         annotations:

--- a/kubernetes/apps/default/radicale/helmrelease.yaml
+++ b/kubernetes/apps/default/radicale/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       radicale:
         annotations:

--- a/kubernetes/apps/default/silverbullet/helmrelease.yaml
+++ b/kubernetes/apps/default/silverbullet/helmrelease.yaml
@@ -27,6 +27,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         strategy: Recreate

--- a/kubernetes/apps/immich/helmrelease.yaml
+++ b/kubernetes/apps/immich/helmrelease.yaml
@@ -26,6 +26,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       server:
         type: deployment

--- a/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
@@ -26,6 +26,8 @@ spec:
       retries: 3
   values:
     worker:
+      securityContext:
+        runAsNonRoot: true
       config:
         core:
           sources: ["pci", "system", "usb", "kernel"]

--- a/kubernetes/apps/media/bazarr/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/helmrelease.yaml
@@ -27,6 +27,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         annotations:

--- a/kubernetes/apps/media/jellyseerr/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyseerr/helmrelease.yaml
@@ -26,6 +26,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         containers:

--- a/kubernetes/apps/media/movary/helmrelease.yaml
+++ b/kubernetes/apps/media/movary/helmrelease.yaml
@@ -28,6 +28,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         containers:

--- a/kubernetes/apps/media/prowlarr/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/helmrelease.yaml
@@ -27,6 +27,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         strategy: Recreate

--- a/kubernetes/apps/media/qbittorrent/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/helmrelease.yaml
@@ -23,6 +23,9 @@ spec:
       strategy: rollback
       retries: 3
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       qbittorrent:
         annotations:

--- a/kubernetes/apps/media/radarr/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/helmrelease.yaml
@@ -27,6 +27,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         strategy: Recreate

--- a/kubernetes/apps/media/sonarr/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/helmrelease.yaml
@@ -27,6 +27,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         strategy: Recreate

--- a/kubernetes/apps/monitoring/alertmanager/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/alertmanager/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         type: statefulset

--- a/kubernetes/apps/monitoring/alloy/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/alloy/helmrelease.yaml
@@ -29,7 +29,12 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    global:
+      podSecurityContext:
+        runAsNonRoot: true
     alloy:
+      securityContext:
+        runAsNonRoot: true
       extraEnv:
         - name: CLUSTER_ID
           value: homelab

--- a/kubernetes/apps/monitoring/restic-exporter/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/restic-exporter/helmrelease.yaml
@@ -15,6 +15,9 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       restic-exporter:
         containers:

--- a/kubernetes/apps/monitoring/speedtest-exporter/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/speedtest-exporter/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
         name: bjw-s-helm-charts
         namespace: flux-system
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       speedtest-exporter:
         containers:

--- a/kubernetes/apps/music/deemix/helmrelease.yaml
+++ b/kubernetes/apps/music/deemix/helmrelease.yaml
@@ -26,6 +26,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         containers:

--- a/kubernetes/apps/music/navidrome/helmrelease.yaml
+++ b/kubernetes/apps/music/navidrome/helmrelease.yaml
@@ -28,6 +28,9 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       main:
         annotations:

--- a/kubernetes/apps/network/cloudflared/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/helmrelease.yaml
@@ -24,6 +24,9 @@ spec:
     remediation:
       retries: 3
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
     controllers:
       cloudflared:
         replicas: 2

--- a/kubernetes/apps/network/envoy-gateway/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/helmrelease.yaml
@@ -24,6 +24,10 @@ spec:
     remediation:
       retries: 3
   values:
+    deployment:
+      envoyGateway:
+        securityContext:
+          runAsNonRoot: true
     config:
       envoyGateway:
         extensionApis:

--- a/kubernetes/apps/network/tailscale/helmrelease.yaml
+++ b/kubernetes/apps/network/tailscale/helmrelease.yaml
@@ -17,6 +17,10 @@ spec:
       interval: 5m
   values:
     operatorConfig:
+      podSecurityContext:
+        runAsNonRoot: true
+      securityContext:
+        runAsNonRoot: true
       hostname: tailscale-operator
       defaultTags:
         - tag:k8s

--- a/kubernetes/apps/system/reloader/helmrelease.yaml
+++ b/kubernetes/apps/system/reloader/helmrelease.yaml
@@ -24,6 +24,8 @@ spec:
       reloadStrategy: annotations
 
       deployment:
+        securityContext:
+          runAsNonRoot: true
         resources:
           requests:
             cpu: 5m


### PR DESCRIPTION
Adds runAsNonRoot security context defaults across HelmRelease values in kubernetes/apps.\n\nThis makes chart-rendered workloads opt into non-root execution wherever the chart supports top-level securityContext values.