### PR TITLE
fix(media): run media apps as shared user

### DIFF
--- a/kubernetes/apps/default/fresh-rss/helmrelease.yaml
+++ b/kubernetes/apps/default/fresh-rss/helmrelease.yaml
@@ -33,10 +33,6 @@ spec:
       freshrss:
         annotations:
           reloader.stakater.com/auto: 'true'
-        pod:
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
         initContainers:
           init-db:
             image:

--- a/kubernetes/apps/media/bazarr/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/helmrelease.yaml
@@ -63,6 +63,9 @@ spec:
                 memory: 256Mi
               limits:
                 memory: 512Mi
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
     service:
       bazarr:
         controller: main

--- a/kubernetes/apps/media/jellyfin/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/helmrelease.yaml
@@ -55,6 +55,8 @@ spec:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: {drop: ['ALL']}
+              runAsUser: 1000
+              runAsGroup: 1000
             resources:
               requests:
                 cpu: 100m

--- a/kubernetes/apps/media/jellyseerr/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyseerr/helmrelease.yaml
@@ -42,6 +42,9 @@ spec:
                 memory: 200Mi
               limits:
                 memory: 500Mi
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
     service:
       main:
         controller: main

--- a/kubernetes/apps/media/movary/helmrelease.yaml
+++ b/kubernetes/apps/media/movary/helmrelease.yaml
@@ -50,6 +50,9 @@ spec:
                 memory: 256Mi
               limits:
                 memory: 256Mi
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
     service:
       main:
         controller: main

--- a/kubernetes/apps/media/prowlarr/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/helmrelease.yaml
@@ -62,6 +62,9 @@ spec:
                 memory: 256Mi
               limits:
                 memory: 512Mi
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
     service:
       main:
         controller: main

--- a/kubernetes/apps/media/qbittorrent/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/helmrelease.yaml
@@ -57,6 +57,8 @@ spec:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: {drop: ['ALL']}
+              runAsUser: 1000
+              runAsGroup: 1000
             resources:
               requests:
                 cpu: 10m

--- a/kubernetes/apps/media/radarr/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/helmrelease.yaml
@@ -64,6 +64,8 @@ spec:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: {drop: ['ALL']}
+              runAsUser: 1000
+              runAsGroup: 1000
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/apps/media/sonarr/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/helmrelease.yaml
@@ -68,6 +68,9 @@ spec:
                 memory: 150Mi
               limits:
                 memory: 300Mi
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
     service:
       main:
         controller: main


### PR DESCRIPTION
Media workloads need consistent file ownership for shared media/config volumes.

Set `runAsUser` and `runAsGroup` to `1000` across Bazarr, Jellyfin, Jellyseerr, Movary, Prowlarr, qBittorrent, Radarr, and Sonarr so containers write files with the expected UID/GID.