### PR TITLE
feat: add Policy Reporter UI

### DIFF
--- a/kubernetes/apps/kyverno/policy-reporter/chart-values.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/chart-values.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: policy-reporter-chart-values
+data:
+  values.yaml: |-
+    serviceAccount:
+      automount: true
+
+    podSecurityContext:
+      runAsUser: 1234
+      runAsGroup: 1234
+      fsGroup: 1234
+      fsGroupChangePolicy: OnRootMismatch
+      seccompProfile:
+        type: RuntimeDefault
+
+    securityContext:
+      runAsUser: 1234
+      runAsGroup: 1234
+      runAsNonRoot: true
+      privileged: false
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+
+    resources:
+      requests:
+        cpu: 5m
+        memory: 75Mi
+      limits:
+        memory: 128Mi
+
+    rest:
+      enabled: true
+
+    metrics:
+      enabled: true
+
+    ui:
+      enabled: true
+      displayMode: dark
+
+      serviceAccount:
+        automount: false
+
+      podSecurityContext:
+        runAsUser: 1234
+        runAsGroup: 1234
+        fsGroup: 1234
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+      securityContext:
+        runAsUser: 1234
+        runAsGroup: 1234
+        runAsNonRoot: true
+        privileged: false
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+
+      resources:
+        requests:
+          cpu: 5m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+
+      sources:
+        - name: kyverno
+          exceptions: false
+
+      clusters:
+        - name: homelab
+          host: http://policy-reporter:8080
+      httproute:
+        enabled: true
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        hostnames:
+          - policy-reporter.${HOMELAB_DOMAIN}

--- a/kubernetes/apps/kyverno/policy-reporter/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/helmrelease.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app policy-reporter
+spec:
+  interval: 3h
+  releaseName: *app
+  chart:
+    spec:
+      chart: *app
+      version: 3.7.4
+      sourceRef:
+        kind: HelmRepository
+        name: policy-reporter
+        namespace: flux-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: &retries 3
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      retries: *retries
+  valuesFrom:
+    - kind: ConfigMap
+      name: policy-reporter-chart-values

--- a/kubernetes/apps/kyverno/policy-reporter/kustomization.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./chart-values.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/base/helmrepositories/kustomization.yaml
+++ b/kubernetes/base/helmrepositories/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - kyverno.yaml
   - longhorn.yaml
   - node-feature-discovery.yaml
+  - policy-reporter.yaml
   - prometheus-community.yaml
   - stakater.yaml
   - tailscale.yaml

--- a/kubernetes/base/helmrepositories/policy-reporter.yaml
+++ b/kubernetes/base/helmrepositories/policy-reporter.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: policy-reporter
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kyverno.github.io/policy-reporter

--- a/kubernetes/base/kustomizations/kyverno/kustomization.yaml
+++ b/kubernetes/base/kustomizations/kyverno/kustomization.yaml
@@ -4,3 +4,4 @@ buildMetadata: [originAnnotations]
 resources:
   - ./kyverno.yaml
   - ./policies.yaml
+  - ./policy-reporter.yaml

--- a/kubernetes/base/kustomizations/kyverno/policy-reporter.yaml
+++ b/kubernetes/base/kustomizations/kyverno/policy-reporter.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: policy-reporter
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./kubernetes/apps/kyverno/policy-reporter
+  prune: true
+  targetNamespace: monitoring
+  dependsOn:
+    - name: kyverno
+  sourceRef:
+    kind: GitRepository
+    name: flux-system


### PR DESCRIPTION
Installs Policy Reporter in the monitoring namespace for browsing Kyverno policy reports.\n\nUses the shared HelmRepository directory, deploys via Flux, and exposes the UI through the internal Envoy Gateway route. Configures restricted pod security contexts, no UI service account token automount, and resource bounds for least-privilege defaults.