### PR TITLE
feat: add Keycloak identity provider

### DIFF
--- a/kubernetes/apps/auth/keycloak/cluster.yaml
+++ b/kubernetes/apps/auth/keycloak/cluster.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: keycloak
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:17
+  primaryUpdateStrategy: unsupervised
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: keycloak-app
+  storage:
+    size: 5Gi
+    storageClass: longhorn-local
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: cnpg-superuser
+  monitoring:
+    enablePodMonitor: true
+  enablePDB: false
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 50m
+    limits:
+      memory: 2Gi

--- a/kubernetes/apps/auth/keycloak/helmrelease.yaml
+++ b/kubernetes/apps/auth/keycloak/helmrelease.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: keycloak
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: keycloak
+      version: 25.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    production: true
+    proxyHeaders: xforwarded
+    auth:
+      adminUser: admin
+      existingSecret: keycloak-admin
+      passwordSecretKey: admin-password
+    postgresql:
+      enabled: false
+    externalDatabase:
+      host: keycloak-rw.auth.svc.cluster.local
+      port: 5432
+      user: keycloak
+      database: keycloak
+      existingSecret: keycloak-app
+      existingSecretPasswordKey: password
+    service:
+      type: ClusterIP
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+    resourcesPreset: none
+    resources:
+      requests:
+        cpu: 100m
+        memory: 768Mi
+      limits:
+        memory: 1536Mi

--- a/kubernetes/apps/auth/keycloak/httproute.yaml
+++ b/kubernetes/apps/auth/keycloak/httproute.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: keycloak
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - keycloak.${HOMELAB_DOMAIN}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: keycloak
+          port: 80

--- a/kubernetes/apps/auth/keycloak/kustomization.yaml
+++ b/kubernetes/apps/auth/keycloak/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: auth
+resources:
+  - ./secret.sops.yaml
+  - ./cluster.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/auth/keycloak/secret.sops.yaml
+++ b/kubernetes/apps/auth/keycloak/secret.sops.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: keycloak-admin
+stringData:
+    admin-password: ENC[AES256_GCM,data:wmWZqwdgF6AVqw6j+uHryFjzpiXa9wXlQ4MMFhTybFFy0NIM6JAi1H1EDIc=,iv:Lu3lJkMoSHqnerH/KB7HHUapX8ymiKtgXwugZGglHmw=,tag:KxV4X9fj+5T6b96qDcVP6A==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTcDFiMitXWER6ckVPVXJD
+            YjRXV1NhdEV0c1BhS1MyVFhwUDE0VDFHc1NNCjBTeGsyOW1mVmsvSWVJM2xNWjh3
+            QnVwVlhVN1NtMjhka1pWZDliaVBKREEKLS0tIDlNUUt2OXpnV2pYRWNlUVNvczY2
+            cm9qUXl6NUZ5VHBoVjBhVUI1SXBSKzQKLkVNxqw16NSX0L8cekAEj66aJWCJ195F
+            oUF/lKUSVSwKwdrKNIrXBjXa/8wjkJkA1JKzQDAq5f6JyKQZyODlHg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1nk8j4vujprxg5ep7vlgektc8wndmywh9lx4yl5k3flfxdnf9t4xqlu745k
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-31T08:44:47Z"
+    mac: ENC[AES256_GCM,data:gWS6sbozMOAjK2Xbdbij2J1WQZIgQT5n4xqcJ6nAuYSbPVja4yeRC37sdOrbmYP1g+Hmn8u6yhva5b7KFuZA5Eqe4vWXo5PUrbqjOrDb7UntUbSWqD+PVhO1j6wwjiFHk85O6bhXW8k+Oc2YAjEsXDrxnLR9Fj+lgWAIs7WmUXg=,iv:sRmaN9xnLPVL/yQgoPTQ4WMXRUrfDyticeRLW+RG22g=,tag:4qBgafoZMZnewlXBqpzuow==,type:str]
+    version: 3.13.1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: keycloak-app
+type: kubernetes.io/basic-auth
+stringData:
+    username: ENC[AES256_GCM,data:PIKL9V2OLk4=,iv:bd1YJ6ryo3nV1sHHoieRTGeQ/dw7A6zoN3Ruh3EuccM=,tag:3kRT1ySia8r3ISz6CkCqrg==,type:str]
+    password: ENC[AES256_GCM,data:Ze7S1c3QVs1GyFaxbVlstH/7nNSjfcxGqMA4HtDapdkh4biAzR1wvXCqZRo=,iv:Wym4/rR4La/1o0dG959WtB6WVKUyjrj8IBCzA3AkweI=,tag:6ND2NQPdp0NVkPMRuj1ZSg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTcDFiMitXWER6ckVPVXJD
+            YjRXV1NhdEV0c1BhS1MyVFhwUDE0VDFHc1NNCjBTeGsyOW1mVmsvSWVJM2xNWjh3
+            QnVwVlhVN1NtMjhka1pWZDliaVBKREEKLS0tIDlNUUt2OXpnV2pYRWNlUVNvczY2
+            cm9qUXl6NUZ5VHBoVjBhVUI1SXBSKzQKLkVNxqw16NSX0L8cekAEj66aJWCJ195F
+            oUF/lKUSVSwKwdrKNIrXBjXa/8wjkJkA1JKzQDAq5f6JyKQZyODlHg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1nk8j4vujprxg5ep7vlgektc8wndmywh9lx4yl5k3flfxdnf9t4xqlu745k
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-31T08:44:47Z"
+    mac: ENC[AES256_GCM,data:gWS6sbozMOAjK2Xbdbij2J1WQZIgQT5n4xqcJ6nAuYSbPVja4yeRC37sdOrbmYP1g+Hmn8u6yhva5b7KFuZA5Eqe4vWXo5PUrbqjOrDb7UntUbSWqD+PVhO1j6wwjiFHk85O6bhXW8k+Oc2YAjEsXDrxnLR9Fj+lgWAIs7WmUXg=,iv:sRmaN9xnLPVL/yQgoPTQ4WMXRUrfDyticeRLW+RG22g=,tag:4qBgafoZMZnewlXBqpzuow==,type:str]
+    version: 3.13.1

--- a/kubernetes/base/helmrepositories/bitnami.yaml
+++ b/kubernetes/base/helmrepositories/bitnami.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: bitnami
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.bitnami.com/bitnami
+  timeout: 3m

--- a/kubernetes/base/helmrepositories/kustomization.yaml
+++ b/kubernetes/base/helmrepositories/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 buildMetadata: [originAnnotations]
 resources:
+  - bitnami.yaml
   - bjw-s.yaml
   - cert-manager.yaml
   - cloudnative-pg.yaml

--- a/kubernetes/base/kustomizations/auth/keycloak.yaml
+++ b/kubernetes/base/kustomizations/auth/keycloak.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: keycloak
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/auth/keycloak
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/kubernetes/base/kustomizations/auth/kustomization.yaml
+++ b/kubernetes/base/kustomizations/auth/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+buildMetadata: [originAnnotations]
+resources:
+  - keycloak.yaml

--- a/kubernetes/base/kustomizations/kustomization.yaml
+++ b/kubernetes/base/kustomizations/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 buildMetadata: [originAnnotations]
 resources:
+  - auth
   - cert-manager
   - dbms
   - default

--- a/kubernetes/base/namespaces/auth.yaml
+++ b/kubernetes/base/namespaces/auth.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: auth
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/base/namespaces/kustomization.yaml
+++ b/kubernetes/base/namespaces/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - auth.yaml
   - cert-manager.yaml
   - dbms.yaml
   - forgejo.yaml


### PR DESCRIPTION
Adds Keycloak as the homelab identity provider.

Keycloak is deployed in the new `auth` namespace using the Bitnami chart and backed by a dedicated CloudNativePG PostgreSQL cluster. The app is exposed internally through Envoy Gateway at `keycloak.${HOMELAB_DOMAIN}` with SOPS-encrypted admin and database credentials.

This sets up the foundation for OIDC/SSO integrations across apps and future gateway-level auth.