### PR TITLE
feat: add authentik deployment

### DIFF
--- a/kubernetes/apps/authentik/authentik/helmrelease.yaml
+++ b/kubernetes/apps/authentik/authentik/helmrelease.yaml
@@ -1,0 +1,77 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: authentik
+  namespace: authentik
+spec:
+  interval: 30m
+  timeout: 10m
+  chartRef:
+    kind: OCIRepository
+    name: authentik
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    global:
+      deploymentStrategy:
+        type: RollingUpdate
+      podAnnotations:
+        secret.reloader.stakater.com/reload: authentik-secret
+      env:
+        - name: TZ
+          value: ${TZ}
+      envFrom:
+        - secretRef:
+            name: authentik-secret
+    authentik:
+      existingSecret:
+        secretName: authentik-secret
+      error_reporting:
+        enabled: false
+    server:
+      replicas: 1
+      initContainers:
+        - name: init-db
+          image: ghcr.io/onedr0p/postgres-init:16
+          envFrom:
+            - secretRef:
+                name: authentik-secret
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 1Gi
+      metrics:
+        serviceMonitor:
+          enabled: true
+      route:
+        main:
+          enabled: true
+          hostnames:
+            - auth.${HOMELAB_DOMAIN}
+          parentRefs:
+            - name: envoy-internal
+              namespace: network
+              sectionName: https
+    worker:
+      replicas: 1
+      initContainers:
+        - name: init-db
+          image: ghcr.io/onedr0p/postgres-init:16
+          envFrom:
+            - secretRef:
+                name: authentik-secret
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 1Gi

--- a/kubernetes/apps/authentik/authentik/kustomization.yaml
+++ b/kubernetes/apps/authentik/authentik/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: authentik
+resources:
+  - ocirepository.yaml
+  - secret.sops.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/authentik/authentik/ocirepository.yaml
+++ b/kubernetes/apps/authentik/authentik/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: authentik
+  namespace: authentik
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2026.5.0
+  url: oci://ghcr.io/goauthentik/helm-charts/authentik

--- a/kubernetes/apps/authentik/authentik/secret.sops.yaml
+++ b/kubernetes/apps/authentik/authentik/secret.sops.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: authentik-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:Sb0LEV958+wMFA6wsmxQjsN2nlut0jtXsMtUKP6SGEs5CMdYnMptDg776fV04rS4zCw7/vQFB8TDZgxiTCfGsBlEOYN8DR3ZWbLBOqmJldw=,iv:kGgMOuekEcZRVr01H5FLbqjIXL6VvXJoVCyqosqbRdA=,tag:GSccJmFP0hl1AAy+IoPfzg==,type:str]
+    AUTHENTIK_BOOTSTRAP_EMAIL: ENC[AES256_GCM,data:x/akPu+e3CAeoAI1TVsic4XAbGCvGgs=,iv:Ok1WyKzWjVeXPGZEjPUv88U3s4c93KEktq1Sk3dI5O4=,tag:QZaKT8ueCbDpUxGwP6AyZw==,type:str]
+    AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:y9K+uZbzGGfRCr2J5Qkb9EkOAy1ogjL5,iv:lnxtcLr2LKt2NSRScx/W+/JftcLuOSV7eU/P6gAHzuY=,tag:4mUjjiSMwMs5E6fK/N8Y8Q==,type:str]
+    AUTHENTIK_POSTGRESQL__HOST: ENC[AES256_GCM,data:VVyFaCmNXLMMd6D8jJUqCw==,iv:2yPf8SUy7DvnU7DvY1+O0EwPcmZfBFnTBGKnZcd/UcE=,tag:P2bIZqe0MoxI4q11wglIrA==,type:str]
+    AUTHENTIK_POSTGRESQL__NAME: ENC[AES256_GCM,data:8IDd+gUKbLEH,iv:/AWBHaoDCUVqo0+mujoAA+WAbqBo1vdkRf+/ISiSSKM=,tag:ZLIt/TXOukI5H/H78BUq9A==,type:str]
+    AUTHENTIK_POSTGRESQL__USER: ENC[AES256_GCM,data:X0Znb7dggzPZ,iv:HH69C7F5zep7NxWFEdWQF4PKobN5eicjBkoXHRldc+Q=,tag:vaYPq/4c0tnib2i8V2UKEg==,type:str]
+    AUTHENTIK_POSTGRESQL__PASSWORD: ENC[AES256_GCM,data:0bx4xB36p3FYUSpB8vbBvhczjKQvHpaB,iv:U6oIW3fv11cVX7ZNxG/jkkr4KB0xQX0+C1MF3o+897s=,tag:HwlbX/EqYM62XPAGfAbrag==,type:str]
+    INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:flwNQim2Q5OQ,iv:Kx7oTAURI2nf6XjcvgLPJN9s65WqPzuoDpMZQnbcnXs=,tag:n5hyJpM+EsuPW18Qc3h9UQ==,type:str]
+    INIT_POSTGRES_HOST: ENC[AES256_GCM,data:UXvejoGNbbMW0BQuH7XkRg==,iv:wVsgIla6F7kZ8EwpUzaeINJxIYDQ6wJywprdIn3Xl20=,tag:rmlb4HcbDxQSnYFCBV8Knw==,type:str]
+    INIT_POSTGRES_USER: ENC[AES256_GCM,data:W2Ko3umbRHUL,iv:79en/VkYAU77er2Jvj+Q/4JBCHwrAT+I93ryqw1ROiU=,tag:ojOcu2TEuY2FG1DevFRqGQ==,type:str]
+    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:cRxX9mp7c6PJlhjin5aZwhpsscbCPNBO,iv:PU68vcHhMvNR0Z91inKVO75J/TdRLpvokx7Ah6Lo+gI=,tag:656JU+YaCu0DRheBJqdtvA==,type:str]
+    INIT_POSTGRES_SUPER_USER: ENC[AES256_GCM,data:Yg4ewZG6y7g=,iv:LxnFiQYb9T29RqeLpMo7VKJ5dvLXuQxtG07bQD1YdS0=,tag:Tf5Av4XwrH1j8MgeShFHlQ==,type:str]
+    INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:Fk5dU3quqhw=,iv:B3NYDhnQHYIZ0qRdjMwgc0nHwHC9Pth7AP3TyIzb8I8=,tag:lKVVFfiJJkcti6xQg/g88Q==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzTy9Ya0hMVW9MSE44QVds
+            MWpzZzZnbTJZTkREclVjMlAzNGZERVVEVW44ClcyQnBQQUw2MDNueHM4VlQ0S24w
+            MVlzbzJrMXhXMzRGS1RuTGFUM3lZUmMKLS0tIDhOckw4NmxOdnZaSmZMZDFCMUx3
+            SWNRQUtmVm1LS01ReXljT0FRN3BOK0EKzopTYAyjBGGoXFtb5XiwLyKkpkVyquCU
+            DkHD5KvVh+cRGxu8XrfSZDnwFeZOUSeIkIofNZzAAmpH5smfiNKrsA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1nk8j4vujprxg5ep7vlgektc8wndmywh9lx4yl5k3flfxdnf9t4xqlu745k
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-31T09:35:42Z"
+    mac: ENC[AES256_GCM,data:w370dlwS2uktIG4tqqA2CR85tPDSXPAu9+zH+HhChUVPdb8vN+JhZXxhHBygE3ztwOh3YCLlRfa0FAoASre0W4KwAvaFkP6bFvyGmB5RVb9aleWZga7PQxUD3zVsFnSTmbHzOrBV/ZjdTY2SHfuHFQgQvV96u26aa6+j08gqG7A=,iv:zZ5fQya6EBpacGyC50SzvzP7PBcaBFxOMSgIFZknm1M=,tag:peY2daKQRhseijyN8hb83Q==,type:str]
+    version: 3.13.1

--- a/kubernetes/base/kustomizations/authentik/authentik.yaml
+++ b/kubernetes/base/kustomizations/authentik/authentik.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: authentik
+  namespace: flux-system
+spec:
+  interval: 10m
+  targetNamespace: authentik
+  path: ./kubernetes/apps/authentik/authentik
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: cloudnative-pg-clusters
+  wait: false
+  timeout: 10m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/kubernetes/base/kustomizations/authentik/kustomization.yaml
+++ b/kubernetes/base/kustomizations/authentik/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+buildMetadata: [originAnnotations]
+resources:
+  - authentik.yaml

--- a/kubernetes/base/kustomizations/kustomization.yaml
+++ b/kubernetes/base/kustomizations/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 buildMetadata: [originAnnotations]
 resources:
+  - authentik
   - cert-manager
   - dbms
   - default

--- a/kubernetes/base/namespaces/authentik.yaml
+++ b/kubernetes/base/namespaces/authentik.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: authentik

--- a/kubernetes/base/namespaces/kustomization.yaml
+++ b/kubernetes/base/namespaces/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - authentik.yaml
   - cert-manager.yaml
   - dbms.yaml
   - forgejo.yaml


### PR DESCRIPTION
Adds Authentik as a dedicated Flux-managed app in its own namespace.

Includes the Authentik Helm OCI source, HelmRelease, SOPS-encrypted bootstrap/database secrets, and a CNPG PostgreSQL cluster. Wires the new namespace and Flux Kustomization into the base tree with an internal route at `auth.${HOMELAB_DOMAIN}`.