### PR TITLE
kyverno: enforce require-readonly-rootfs for default namespace

### DIFF
--- a/kubernetes/apps/kyverno/policies/require-readonly-rootfs.yaml
+++ b/kubernetes/apps/kyverno/policies/require-readonly-rootfs.yaml
@@ -13,7 +13,7 @@ metadata:
       if the container exits. This policy ensures that containers specify
       readOnlyRootFilesystem: true.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: require-readonly-rootfs
@@ -22,27 +22,8 @@ spec:
         - resources:
             kinds:
               - Pod
-      exclude:
-        any:
-        - resources:
             namespaces:
-              - storage
-        - resources:
-            namespaces:
-              - metallb-system
-        - resources:
-            namespaces:
-              - kube-system
-            names:
-              - kube-vip-ds*
-        - resources:
-            namespaces:
-              - network
-            names:
-              - csi-smb-controller*
-              - csi-smb-node*
-              - operator*
-              - ts-subnet-router*
+              - default
       validate:
         message: >-
           Containers must use a read-only root filesystem. Set


### PR DESCRIPTION
Change validationFailureAction from Audit to Enforce and scope the match to the default namespace only. Other namespaces no longer match this rule.

Flux (kyverno-policies Kustomization, 5m interval) will reconcile shortly. Expand cluster-wide later by removing the namespaces filter.