### PR TITLE
fix(fresh-rss): add emptyDir mount for /var/run to fix crash with readOnlyRootFilesystem

### DIFF
--- a/kubernetes/apps/default/fresh-rss/helmrelease.yaml
+++ b/kubernetes/apps/default/fresh-rss/helmrelease.yaml
@@ -81,6 +81,10 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /tmp
+      run:
+        type: emptyDir
+        globalMounts:
+          - path: /var/run
     route:
       app:
         hostnames:


### PR DESCRIPTION
The Kyverno require-readonly-rootfs policy (enforced in f3f3943) combined with readOnlyRootFilesystem: true (added in 75cbfe8) caused FreshRSS to crash-loop because cron needs to write its PID to /var/run/crond.pid. The existing emptyDir for /tmp wasn't enough — /var/run was still read-only.