### PR TITLE
fix(fresh-rss): add CHOWN and FOWNER capabilities for data permissions

### DIFF
--- a/kubernetes/apps/default/fresh-rss/helmrelease.yaml
+++ b/kubernetes/apps/default/fresh-rss/helmrelease.yaml
@@ -63,6 +63,9 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
+              add:
+                - CHOWN
+                - FOWNER
               drop:
                 - ALL
     service:


### PR DESCRIPTION
FreshRSS was crash-looping after the `readOnlyRootFilesystem` and `drop: [ALL]` security hardening (commits f3f3943, 75cbfe8).

Two issues:
1. `/var/run` was read-only — crond couldn't write its PID → fixed in #962
2. Even after that fix, the pod still crashed because `access-permissions.sh` needs `chown`/`chmod` on the data PVC, which require `CAP_CHOWN` and `CAP_FOWNER` — all capabilities were dropped

Adds `CHOWN` and `FOWNER` to the capabilities list so the entrypoint can set correct group ownership and permissions on the data directory. The `readOnlyRootFilesystem` restriction and the rest of the hardening remain in place.