### PR TITLE
kyverno: extend require-readonly-rootfs policy to media and music namespaces

### DIFF
--- a/kubernetes/apps/kyverno/policies/require-readonly-rootfs.yaml
+++ b/kubernetes/apps/kyverno/policies/require-readonly-rootfs.yaml
@@ -24,6 +24,8 @@ spec:
               - Pod
             namespaces:
               - default
+              - media
+              - music
       validate:
         message: >-
           Containers must use a read-only root filesystem. Set

--- a/kubernetes/apps/media/bazarr/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/helmrelease.yaml
@@ -70,6 +70,7 @@ spec:
         defaultContainerOptions:
           securityContext:
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/kubernetes/apps/media/movary/helmrelease.yaml
+++ b/kubernetes/apps/media/movary/helmrelease.yaml
@@ -57,6 +57,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 3000
             runAsGroup: 3000
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/kubernetes/apps/music/deemix/helmrelease.yaml
+++ b/kubernetes/apps/music/deemix/helmrelease.yaml
@@ -53,6 +53,7 @@ spec:
         defaultContainerOptionsStrategy: merge
         defaultContainerOptions:
           securityContext:
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/kubernetes/apps/music/navidrome/helmrelease.yaml
+++ b/kubernetes/apps/music/navidrome/helmrelease.yaml
@@ -68,6 +68,7 @@ spec:
         defaultContainerOptionsStrategy: merge
         defaultContainerOptions:
           securityContext:
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:


### PR DESCRIPTION
Add media and music to the require-readonly-rootfs ClusterPolicy match namespaces so the policy enforces read-only root filesystem across all three namespaces (default, media, music).

Also add readOnlyRootFilesystem: true to apps that were missing it:
- media: bazarr, movary
- music: deemix, navidrome