### PR TITLE
fix(fresh-rss): add missing DAC_OVERRIDE capability to allow chmod on…

### DIFF
--- a/kubernetes/apps/default/fresh-rss/helmrelease.yaml
+++ b/kubernetes/apps/default/fresh-rss/helmrelease.yaml
@@ -65,6 +65,7 @@ spec:
             capabilities:
               add:
                 - CHOWN
+                - DAC_OVERRIDE  # required: root needs this to chmod files owned by www-data (UID 82) on the PVC
                 - FOWNER
               drop:
                 - ALL


### PR DESCRIPTION
… PVC data

The FreshRSS pod was CrashLoopBackOff after a Helm upgrade. The container runs as root with all capabilities dropped except CHOWN and FOWNER. Its entrypoint script tries to chmod files in the PVC data directory, but those files are owned by www-data (UID 82) from a previous deployment. Without DAC_OVERRIDE, root cannot bypass file permission checks, so the chmod operations fail and the container exits.

Adding DAC_OVERRIDE allows root to modify files owned by other users on the PVC, letting the entrypoint complete. The pending Helm upgrade, once reconciled, will also mount an emptyDir at /var/run to fix a secondary cron read-only filesystem error.