### PR TITLE
chore: remove readOnlyRootFS constraint from FreshRSS and exclude from Kyverno policy

### DIFF
--- a/kubernetes/apps/default/fresh-rss/helmrelease.yaml
+++ b/kubernetes/apps/default/fresh-rss/helmrelease.yaml
@@ -60,13 +60,8 @@ spec:
         defaultContainerOptionsStrategy: merge
         defaultContainerOptions:
           securityContext:
-            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
-              add:
-                - CHOWN
-                - DAC_OVERRIDE  # required: root needs this to chmod files owned by www-data (UID 82) on the PVC
-                - FOWNER
               drop:
                 - ALL
     service:

--- a/kubernetes/apps/kyverno/policies/require-readonly-rootfs.yaml
+++ b/kubernetes/apps/kyverno/policies/require-readonly-rootfs.yaml
@@ -26,6 +26,13 @@ spec:
               - default
               - media
               - music
+      exclude:
+        any:
+        - resources:
+            namespaces:
+              - default
+            names:
+              - freshrss-*
       validate:
         message: >-
           Containers must use a read-only root filesystem. Set


### PR DESCRIPTION
FreshRSS needs writable rootfs and no longer requires extra capabilities.

- Removed `readOnlyRootFilesystem: true` from FreshRSS security context
- Removed extra capabilities (CHOWN, DAC_OVERRIDE, FOWNER), kept drop: [ALL]
- Added `freshrss-*` exclusion to Kyverno `require-readonly-rootfs` policy