### PR TITLE
fix(deemix): add explicit readOnlyRootFilesystem to pass Kyverno policy

### DIFF
--- a/kubernetes/apps/music/deemix/helmrelease.yaml
+++ b/kubernetes/apps/music/deemix/helmrelease.yaml
@@ -44,6 +44,8 @@ spec:
             env:
               TZ: ${TZ}
               DEEMIX_SINGLE_USER: true
+            securityContext:
+              readOnlyRootFilesystem: true
             resources:
               requests:
                 cpu: 50m


### PR DESCRIPTION
Deemix pods were blocked by Kyverno's require-readonly-rootfs policy. The HelmRelease relied on defaultContainerOptions.securityContext with a merge strategy to set readOnlyRootFilesystem: true, but the rendered Deployment revision 18 dropped that field.

Moving readOnlyRootFilesystem: true into the container's explicit securityContext bypasses the chart merge-strategy issue and satisfies the Kyverno admission policy.