### PR TITLE
fix(fresh-rss): remove orphaned /var/run emptyDir mount

### DIFF
--- a/kubernetes/apps/default/fresh-rss/helmrelease.yaml
+++ b/kubernetes/apps/default/fresh-rss/helmrelease.yaml
@@ -80,10 +80,6 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /tmp
-      run:
-        type: emptyDir
-        globalMounts:
-          - path: /var/run
     route:
       app:
         hostnames:


### PR DESCRIPTION
The /var/run emptyDir mount was added when readOnlyRootFilesystem: true was set, to give Apache a writable runtime directory. After readOnlyRootFilesystem was removed (rootfs is writable), this emptyDir started overlaying the image's /run/apache2/ directory, causing Apache to fail with: DefaultRuntimeDir must be a valid directory

Remove the orphaned mount — the image's own /run/apache2/ is now accessible directly. The /tmp emptyDir is retained.