### PR TITLE
docs(runbooks): add pod termination recovery hint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,10 @@ Proxmox host
 - lalitpur (bare metal k8s worker)
 - jhapa (bare metal k8s worker)
 
+## Operational Runbooks
+
+- Pod stuck `Terminating`, possible node/runtime reset: `docs/runbooks/pod-stuck-terminating-node-runtime.md`
+
 ## References
 
 Some homelab repos are present in ~/projects/homeops-repos/

--- a/docs/runbooks/pod-stuck-terminating-node-runtime.md
+++ b/docs/runbooks/pod-stuck-terminating-node-runtime.md
@@ -1,0 +1,13 @@
+# Pod stuck Terminating
+
+If a pod is stuck in `Terminating`, try restarting k3s on the node running it:
+
+```bash
+ssh <node>
+sudo systemctl restart k3s-node.service
+# fallback: sudo systemctl restart k3s-agent.service
+```
+
+This can also release stale GPU/device/DRA claims held by the terminating pod.
+
+Do not force-delete/patch Flux-managed resources unless explicitly approved.


### PR DESCRIPTION
Document a concise node-runtime reset option for pods stuck in Terminating, including the k3s service restart command and Flux caution.