### PR TITLE
fix(network): require HTTPS for Fern route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 Read `Readme.md` for current project overview, infrastructure, storage, networking/DNS, backups, setup, and requirements.
 This is a flux managed cluster. Never patch or mutate resources with kubectl.
+Never expose applications over plain HTTP. Gateway/HTTPRoute backends should bind to HTTPS listeners only; HTTP listeners should be absent or used only for redirects to HTTPS.
 
 ## Project Structure
 

--- a/kubernetes/apps/default/rss-reader/helmrelease.yaml
+++ b/kubernetes/apps/default/rss-reader/helmrelease.yaml
@@ -85,8 +85,7 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
-          - name: envoy-external
-            namespace: network
+            sectionName: https
         rules:
           - matches:
               - path:


### PR DESCRIPTION
Fern was attached to Envoy Gateway without selecting a listener and also referenced the HTTP-only external gateway

Bind the route to the internal HTTPS listener only and document that applications must not be exposed over plain HTTP.