### PR TITLE
feat(fern): add metrics monitoring

### DIFF
--- a/kubernetes/apps/default/fern/helmrelease.yaml
+++ b/kubernetes/apps/default/fern/helmrelease.yaml
@@ -139,6 +139,8 @@ spec:
         ports:
           http:
             port: 8181
+          metrics:
+            port: 9090
       admin:
         controller: admin
         ports:

--- a/kubernetes/apps/default/fern/kustomization.yaml
+++ b/kubernetes/apps/default/fern/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - servicemonitor.yaml
   - db-secret.sops.yaml
   - app-secret.sops.yaml
   - admin-secret.sops.yaml

--- a/kubernetes/apps/default/fern/servicemonitor.yaml
+++ b/kubernetes/apps/default/fern/servicemonitor.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: fern
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: fern
+      app.kubernetes.io/service: main
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 1m
+      scrapeTimeout: 10s


### PR DESCRIPTION
Expose Fern's metrics endpoint through its Service and add a ServiceMonitor that scrapes /metrics on port 9090.